### PR TITLE
Docker integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8-slim
+
+WORKDIR app
+
+COPY requirements.txt requirements.txt
+
+RUN python -m pip install -r requirements.txt
+
+COPY toynet toynet
+RUN cd toynet
+
+EXPOSE 8000
+
+CMD [ "python", "/app/toynet/manage.py", "runserver", "0.0.0.0:8000" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  backend:
+    build: .
+    ports:
+      - "8000:8000"
+    networks:
+      - react_front
+
+  frontend:
+    build: https://github.com/Project-Reclass/toynet-react.git#
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+    networks:
+      - react_front
+    environment:
+      - SERVER_URI="http://backend:8000"
+
+networks:
+  react_front:

--- a/toynet/toynet/settings.py
+++ b/toynet/toynet/settings.py
@@ -25,7 +25,9 @@ SECRET_KEY = '$d^_4l_8#z0a5sl3l#2knz0hd%p_#-*crt(z1h95qx9=5f_dy9'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    'backend'
+]
 
 
 # Application definition


### PR DESCRIPTION
This PR adds the initial docker configuration for `toynet-django` including the initial docker-compose.

It also adds `backend` to django's allowed hosts to allow for proxying the frontend to the backend within docker-compose.