### PR TITLE
Creates blue deployment

### DIFF
--- a/.github/workflows/cd-blue.yml
+++ b/.github/workflows/cd-blue.yml
@@ -1,0 +1,53 @@
+name: CD-BLUE
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ BLUE ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: toynet-django-repo
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        cd $GITHUB_WORKSPACE
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition-blue.json
+        container-name: toynet-django-container
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: toynet-django-service
+        cluster: toynet-django-cluster
+        wait-for-service-stability: true

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "toynet-django-container",
+        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-django-repo:33079e8ba6abc60adfe045bbb322fffac7af9bb1",
+        "cpu": 0,
+        "memoryReservation": 256,
+        "portMappings": [{
+            "hostPort": 0,
+            "containerPort": 8000,
+            "protocol": "tcp"
+        }],
+        "essential": true,
+        "mountPoints": [],
+        "volumesFrom": [],
+        "secrets": [{
+            "name": "SECRET_KEY",
+            "valueFrom": "arn:aws:secretsmanager:us-east-2:909056806605:secret:toynet-django-secretkey-dHbN5I"
+        }]
+    }
+]

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -20,7 +20,7 @@
         }
     ],
     "executionRoleArn": "arn:aws:iam::243481923718:role/ecsTaskExecutionRole-toynet-django",
-    "family": "toynet-django",
+#    "family": "toynet-django",
     "volumes": [],
     "placementConstraints": [],
     "requiresCompatibilities": [

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -2,7 +2,7 @@
     "containerDefinitions": [
         {
             "name": "toynet-django-container",
-            "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-django-stage",
+            "image": "243481923718.dkr.ecr.us-east-2.amazonaws.com/toynet-django-stage",
             "cpu": 0,
             "memoryReservation": 256,
             "portMappings": [{
@@ -15,11 +15,11 @@
             "volumesFrom": [],
             "secrets": [{
                 "name": "SECRET_KEY",
-                "valueFrom": "arn:aws:secretsmanager:us-east-2:909056806605:secret:toynet-django-secretkey-dHbN5I"
+                "valueFrom": "arn:aws:secretsmanager:us-east-2:243481923718:secret:toynet-django-secretkey-xkR79T"
             }]
         }
     ],
-    "executionRoleArn": "arn:aws:iam::909056806605:role/ecsTaskExecutionRole-toynet-django",
+    "executionRoleArn": "arn:aws:iam::243481923718:role/ecsTaskExecutionRole-toynet-django",
     "family": "toynet-django",
     "volumes": [],
     "placementConstraints": [],

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -15,7 +15,7 @@
             "volumesFrom": [],
             "secrets": [{
                 "name": "SECRET_KEY",
-                "valueFrom": "arn:aws:secretsmanager:us-east-2:909056806605:secret:toynet-django-secret-key-stage-dHbN5I"
+                "valueFrom": "arn:aws:secretsmanager:us-east-2:909056806605:secret:toynet-django-secretkey-dHbN5I"
             }]
         }
     ],

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -1,20 +1,30 @@
-[
-    {
-        "name": "toynet-django-container",
-        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-django-repo:latest",
-        "cpu": 0,
-        "memoryReservation": 256,
-        "portMappings": [{
-            "hostPort": 0,
-            "containerPort": 8000,
-            "protocol": "tcp"
-        }],
-        "essential": true,
-        "mountPoints": [],
-        "volumesFrom": [],
-        "secrets": [{
-            "name": "SECRET_KEY",
-            "valueFrom": "arn:aws:secretsmanager:us-east-2:909056806605:secret:toynet-django-secretkey-dHbN5I"
-        }]
-    }
-]
+{
+    "containerDefinitions": [
+        {
+            "name": "toynet-django-container",
+            "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-django-stage",
+            "cpu": 0,
+            "memoryReservation": 256,
+            "portMappings": [{
+                "hostPort": 0,
+                "containerPort": 8000,
+                "protocol": "tcp"
+            }],
+            "essential": true,
+            "mountPoints": [],
+            "volumesFrom": [],
+            "secrets": [{
+                "name": "SECRET_KEY",
+                "valueFrom": "arn:aws:secretsmanager:us-east-2:909056806605:secret:toynet-django-secret-key-stage-dHbN5I"
+            }]
+        }
+    ],
+    "executionRoleArn": "arn:aws:iam::909056806605:role/ecsTaskExecutionRole-toynet-django",
+    "family": "toynet-django",
+    "volumes": [],
+    "placementConstraints": [],
+    "requiresCompatibilities": [
+        "EC2"
+    ],
+    "memory": "256"
+}

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "toynet-django-container",
-        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-django-repo:33079e8ba6abc60adfe045bbb322fffac7af9bb1",
+        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-django-repo:latest",
         "cpu": 0,
         "memoryReservation": 256,
         "portMappings": [{


### PR DESCRIPTION
Created a new cd file called cd-blue this file now refers to the proper region "us-east-2" and references the proper task definition "task-definition-blue.json" this should allow the terraform script to properly build the ECR by itself and allow GH Actions to push the image to the pre-existing ECR. 

This change is set to deploy on the BLUE branch and that may be the wrong change but I wanted verification before setting it to master. 

This commit should result in one failure as the ECR hasn't been built since a server side environment hasn't been created. This will be saved until a later date. 